### PR TITLE
Fix Prisma binary target

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,8 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-1.1.x", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- update `schema.prisma` to include binary targets for both OpenSSL 1.1 and 3.0

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68464d75c28c832d99b68203f2d3a341