### PR TITLE
Add dynamic NEXTAUTH_URL for Replit

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -2,6 +2,15 @@ import GoogleProvider from "next-auth/providers/google";
 import apiCall from "@/utils/apiCall";
 import { signIn } from "@/server/auth"
 
+// Dynamically set NEXTAUTH_URL so Google OAuth works in both
+// the deployed and Replit development environments.
+const isProd = process.env.NODE_ENV === "production";
+process.env.NEXTAUTH_URL =
+  process.env.NEXTAUTH_URL ||
+  (isProd
+    ? "https://budgetbuddy.replit.app"
+    : "https://608c4b3b-65b0-4a24-8a5a-03750d141826-00-ikkyw1uswydf.riker.replit.dev");
+
 export const authOptions = {
     pages: {
         signIn: "/"


### PR DESCRIPTION
## Summary
- enable dynamic `NEXTAUTH_URL` resolution so Google OAuth works on
  deployed and Replit dev URLs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684662f5ce44832d8c28a68ba4708fb6