### PR TITLE
Fix db client initialization

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,38 +1,50 @@
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
+
+declare const process: {
+  env: Record<string, string | undefined>;
+};
 
 declare global {
   // eslint-disable-next-line no-var
   var prisma: PrismaClient | undefined;
 }
 
+const globalForPrisma = globalThis as { prisma?: PrismaClient };
+
 let db: PrismaClient;
 
 if (process.env.NODE_ENV === "production") {
   db = new PrismaClient();
 } else {
-  if (!global.prisma) {
-    global.prisma = new PrismaClient({
-      log: ['error'],
+  if (!globalForPrisma.prisma) {
+    globalForPrisma.prisma = new PrismaClient({
+      log: ["error"] as Prisma.LogLevel[],
     });
   }
-  db = global.prisma;
+  db = globalForPrisma.prisma;
 }
 
 // Test database connection
-async function testConnection() {
+async function testConnection(): Promise<void> {
   try {
     await db.$connect();
     console.log("Database connected successfully");
   } catch (error) {
-    console.error("Database connection failed:", error.message);
+    if (error instanceof Error) {
+      console.error("Database connection failed:", error.message);
+    } else {
+      console.error("Database connection failed:", error);
+    }
   }
 }
 
 // Only test connection if POSTGRES_PRISMA_URL is set
 if (process.env.POSTGRES_PRISMA_URL) {
-  testConnection();
+  void testConnection();
 } else {
-  console.warn("POSTGRES_PRISMA_URL not set - database features will be unavailable");
+  console.warn(
+    "POSTGRES_PRISMA_URL not set - database features will be unavailable"
+  );
 }
 
 export default db;


### PR DESCRIPTION
## Summary
- improve Prisma client initialization
- allow type-safe error handling in db connection

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@prisma/client')*

------
https://chatgpt.com/codex/tasks/task_e_684706e33a94832d880afd80966977f7