### PR TITLE
Fix TS usage of auth session and hooks

### DIFF
--- a/src/app/actions/chat.ts
+++ b/src/app/actions/chat.ts
@@ -5,14 +5,7 @@ import { redirect } from 'next/navigation'
 import { type Chat } from '@/lib/types'
 import { getFullUserInfo } from './auth'
 import { kv } from '@vercel/kv'
-
-interface ExtendedSession {
-  id: string
-  name?: string
-  email?: string
-  image?: string
-  isAdmin?: boolean
-}
+import { ExtendedSession } from '@/lib/types'
 
 export async function getChats(userId?: string | null) {
   if (!userId) {

--- a/src/app/dashboard/chat/[id]/page.tsx
+++ b/src/app/dashboard/chat/[id]/page.tsx
@@ -6,11 +6,7 @@ import { getFullUserInfo } from '@/app/actions/auth'
 import { getChat, getMissingKeys } from '@/app/actions/chat'
 import { Chat } from '@/components/chat'
 import { AI } from '@/lib/chat/actions'
-import { UserSession } from '@/lib/types'
-
-interface ExtendedSession extends UserSession {
-  id: string  // ensure it's required
-}
+import { ExtendedSession } from '@/lib/types'
 
 
 export interface ChatPageProps {

--- a/src/app/dashboard/chat/page.tsx
+++ b/src/app/dashboard/chat/page.tsx
@@ -2,19 +2,19 @@ import { nanoid } from '@/lib/utils'
 import { Chat } from '@/components/chat'
 import { AI } from '@/lib/chat/actions'
 // import { auth } from '@/lib/auth'
-import { UserSession } from '@/lib/types'
+import { ExtendedSession } from '@/lib/types'
 import { getMissingKeys } from '@/app/actions/chat';
 import { getFullUserInfo } from '@/app/actions/auth';
 
 export default async function IndexPage() {
   const id = nanoid()
   // const session = await auth()
-  const session = (await getFullUserInfo()) as UserSession;
+  const session = (await getFullUserInfo()) as ExtendedSession;
   const missingKeys = await getMissingKeys()
 
   return (
     <AI initialAIState={{ chatId: id, messages: [] }}>
-      <Chat id={id} session={session as UserSession} missingKeys={missingKeys} />
+      <Chat id={id} session={session as ExtendedSession} missingKeys={missingKeys} />
     </AI>
   )
 }

--- a/src/components/sidebar-desktop.tsx
+++ b/src/components/sidebar-desktop.tsx
@@ -3,12 +3,12 @@ import { Sidebar } from '@/components/sidebar'
 // import { auth } from '@/lib/auth'
 import { ChatHistory } from '@/components/chat-history'
 import { getFullUserInfo } from '@/app/actions/auth'
-import type { UserSession } from '@/lib/types'
+import type { ExtendedSession } from '@/lib/types'
 import { SidebarMobile } from './sidebar-mobile';
 
 export async function SidebarDesktop() {
   // const session = await auth()
-  const session = (await getFullUserInfo()) as UserSession;
+  const session = (await getFullUserInfo()) as ExtendedSession;
 
   if (!session?.id) {
     return null

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,

--- a/src/hooks/useGetAccounts.js
+++ b/src/hooks/useGetAccounts.js
@@ -24,9 +24,9 @@ const useGetAccounts = () => {
 		}
 	}, [dispatch]);
 
-	useEffect(() => {
-		fetchData();
-	}, [dispatch]);
-};
+        useEffect(() => {
+                fetchData();
+        }, [fetchData]);
+}; 
 
 export default useGetAccounts;

--- a/src/hooks/usePlaidInit.js
+++ b/src/hooks/usePlaidInit.js
@@ -17,13 +17,13 @@ const usePlaidInit = () => {
         dispatch(
             setPlaidState({ linkToken: data.link_token, linkSuccess: true })
         );
-    }, [linkToken]);
+    }, [dispatch, linkToken]);
 
     useEffect(() => {
         if (linkToken === null || linkSuccess === false) {
             init();
         }
-    }, [linkToken]);
+    }, [init, linkToken, linkSuccess]);
 };
 
 export default usePlaidInit;

--- a/src/lib/chat/actions.tsx
+++ b/src/lib/chat/actions.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/lib/utils'
 import { saveChat } from '@/app/actions/chat'
 import { SpinnerMessage, UserMessage } from '@/components/chatui/message'
-import { Chat, type UserSession } from '@/lib/types'
+import { Chat, type ExtendedSession } from '@/lib/types'
 import { getFullUserInfo, getAccessToken } from '@/app/actions/auth'
 import CategoryTransactionsSkeleton from '@/components/chatui/category-transaction-skeleton'
 import CategoryTransactions from '@/components/chatui/category-transaction'
@@ -366,7 +366,7 @@ export const AI = createAI<AIState, UIState>({
   onGetUIState: async () => {
     'use server'
 
-    const session = (await getFullUserInfo()) as UserSession
+      const session = (await getFullUserInfo()) as ExtendedSession
 
     if (session) {
       const aiState = getAIState() as Chat
@@ -383,7 +383,7 @@ export const AI = createAI<AIState, UIState>({
     'use server'
 
     // const session = await auth()
-    const session = (await getFullUserInfo()) as UserSession;
+      const session = (await getFullUserInfo()) as ExtendedSession;
 
     if (session) {
       const { chatId, messages } = state

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,6 +23,14 @@ export type UserSession = {
     image: string;
     isNewUser: boolean;
     isAdmin: boolean;
+};
+
+export interface ExtendedSession {
+    id: string;
+    name?: string;
+    email?: string;
+    image?: string;
+    isAdmin?: boolean;
 }
 
 export type User = {


### PR DESCRIPTION
## Summary
- add `ExtendedSession` type in shared types
- rely on `ExtendedSession` where full user info is required
- tweak hook dependencies in several hooks
- adjust `use-toast` effect to run only once

## Testing
- `pnpm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684730a881d4832db64ce49b8dd5cabc