### PR TITLE
Handle categories load state

### DIFF
--- a/src/app/dashboard/transaction/page.tsx
+++ b/src/app/dashboard/transaction/page.tsx
@@ -27,7 +27,7 @@ type AccountMap = { [key: string]: string };
 export default function Transactions() {
     const dispatch = useDispatch<AppDispatch>();
     const searchParams = useSearchParams();
-    const { isItemAccess, isTransactionsLoaded, categories } = useSelector(
+    const { isItemAccess, isTransactionsLoaded, categoriesLoaded } = useSelector(
         (state: RootState) => state.plaid
     );
     const { data: transactions, size: total } = useSelector((state: RootState) => state.transactions);
@@ -104,9 +104,9 @@ export default function Transactions() {
     }, [dispatch, selectedCategories, selectedAccounts, selectedPaymentChannel, filterDate, pageSize, merchantName, selectedFinCategories, fetchData]);
 
     useEffect(() => {
-        if (isEmpty(categories)) dispatch(getAllCategories());
+        if (!categoriesLoaded) dispatch(getAllCategories());
         if (isTransactionsLoaded) fetchData(1);
-    }, [isItemAccess, items, isTransactionsLoaded, dispatch, categories, fetchData]);
+    }, [isItemAccess, items, isTransactionsLoaded, dispatch, categoriesLoaded, fetchData]);
 
     // Create a mapping of account IDs to account names
     const accountIdToName: AccountMap = {};
@@ -159,8 +159,8 @@ export default function Transactions() {
         };
     });
 
-    // Use finalTransactions to determine loading state
-    const isLoading = !finalTransactions || finalTransactions.length === 0;
+    const isLoading = !categoriesLoaded;
+    const noTransactions = categoriesLoaded && finalTransactions.length === 0;
 
     return (
         <main className="min-h-screen p-2 sm:p-4 justify-center m-auto max-w-[95vw] sm:max-w-6xl">
@@ -300,6 +300,10 @@ export default function Transactions() {
                             {Spinner}
                         </Card>
                     </>
+                ) : noTransactions ? (
+                    <Card className="w-full p-8 flex justify-center items-center col-span-full">
+                        No transactions found
+                    </Card>
                 ) : (
                     kpis?.map((item, index) => (
                         <Card key={"kpis" + index} className="w-full p-3 sm:p-4">
@@ -317,17 +321,21 @@ export default function Transactions() {
                     <Card className="w-full p-8 flex justify-center items-center">
                         {Spinner}
                     </Card>
+                ) : noTransactions ? (
+                    <Card className="w-full p-8 flex justify-center items-center">
+                        No transactions found
+                    </Card>
                 ) : (
-                    <TransactionChart 
+                    <TransactionChart
                         button={
-                            <Button 
-                                onClick={toggleFilters} 
-                                variant="outline" 
+                            <Button
+                                onClick={toggleFilters}
+                                variant="outline"
                                 type="button"
                             >
                                 {showChart ? "Hide chart" : "Show chart"}
                             </Button>
-                        } 
+                        }
                     />
                 )
             )}
@@ -335,6 +343,10 @@ export default function Transactions() {
             {isLoading ? (
                 <Card className="mt-4 w-full p-8 flex justify-center items-center">
                     {Spinner}
+                </Card>
+            ) : noTransactions ? (
+                <Card className="mt-4 w-full p-8 flex justify-center items-center">
+                    No transactions found
                 </Card>
             ) : (
                 <ModernTable transactions={finalTransactions} />

--- a/src/store/actions/usePlaid.ts
+++ b/src/store/actions/usePlaid.ts
@@ -103,10 +103,17 @@ export const setAccounts = (payload: any) => (dispatch: Dispatch<Action>) => {
 };
 
 export const getAllCategories = () => async (dispatch: Dispatch<Action>) => {
-	try {
-		const res = await apiCall.get("/api/v1/plaid/categories");
-		dispatch({ type: SET_PLAID_CATEGORY_STATE, payload: res.data });
-	} catch (error) {
-		handleError(error);
-	}
+        try {
+                const res = await apiCall.get("/api/v1/plaid/categories");
+                dispatch({
+                        type: SET_PLAID_CATEGORY_STATE,
+                        payload: {
+                                categories: res.data.categories,
+                                personalFinanceCategories: res.data.personalFinanceCategories,
+                                categoriesLoaded: true
+                        }
+                });
+        } catch (error) {
+                handleError(error);
+        }
 };

--- a/src/store/reducers/plaidReducer.ts
+++ b/src/store/reducers/plaidReducer.ts
@@ -26,6 +26,7 @@ const initialState = {
     institutions: {},
     categories: [],
     personalFinanceCategories: [],
+    categoriesLoaded: false,
     linkTokenError: {
         error_type: "",
         error_code: "",


### PR DESCRIPTION
## Summary
- add `categoriesLoaded` flag to Plaid reducer
- dispatch `categoriesLoaded: true` after fetching category lists
- fetch categories if not yet loaded in the transactions page
- show message when there are no transactions

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ac2e8e14832da54c0447ea2d14c0