### PR TITLE
Fix API error handling

### DIFF
--- a/src/app/api/public/user/[userId]/accounts/route.ts
+++ b/src/app/api/public/user/[userId]/accounts/route.ts
@@ -8,31 +8,18 @@ export async function GET(req: Request, { params }: { params: { userId: string }
     const apiKey = req.headers.get('x-api-key');
     const VALID_API_KEY = process.env.PUBLIC_API_KEY; // This is the API key you defined in the .env file
     if (apiKey !== VALID_API_KEY) {
-        return NextResponse.json({
-            message: "Unauthorized",
-            status: 401,
-        });
+        return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
     if (!userId) {
-        return NextResponse.json({
-            message: "Missing userId in request.",
-            status: 400,
-        });
+        return NextResponse.json({ message: "Missing userId in request." }, { status: 400 });
     }
 
     try {
         const data = await accounts(userId);
-        return NextResponse.json({
-            message: "Authorized",
-            data: data,
-            status: 200,
-        });
+        return NextResponse.json({ message: "Authorized", data: data }, { status: 200 });
     } catch (error) {
         console.error('Error fetching user data:', error);
-        return NextResponse.json({
-            message: "Failed to fetch user data.",
-            status: 500,
-        });
+        return NextResponse.json({ message: "Failed to fetch user data." }, { status: 500 });
     }
 }

--- a/src/app/api/public/user/[userId]/transactions/route.ts
+++ b/src/app/api/public/user/[userId]/transactions/route.ts
@@ -9,17 +9,11 @@ export async function GET(req: Request, { params }: { params: { userId: string }
     const apiKey = req.headers.get('x-api-key');
     const VALID_API_KEY = process.env.PUBLIC_API_KEY; // This is the API key you defined in the .env file
     if (apiKey !== VALID_API_KEY) {
-        return NextResponse.json({
-            message: "Unauthorized",
-            status: 401,
-        });
+        return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
     }
 
     if (!userId) {
-        return NextResponse.json({
-            message: "Missing userId in request.",
-            status: 400,
-        });
+        return NextResponse.json({ message: "Missing userId in request." }, { status: 400 });
     }
 
     try {
@@ -39,16 +33,9 @@ export async function GET(req: Request, { params }: { params: { userId: string }
             }
         });
 
-        return NextResponse.json({
-            message: "Authorized",
-            data: transactions,
-            status: 200,
-        });
+        return NextResponse.json({ message: "Authorized", data: transactions }, { status: 200 });
     } catch (error) {
         console.error('Error fetching transactions:', error);
-        return NextResponse.json({
-            message: "Failed to fetch transactions.",
-            status: 500,
-        });
+        return NextResponse.json({ message: "Failed to fetch transactions." }, { status: 500 });
     }
 }

--- a/src/app/api/v1/chat/[id]/route.js
+++ b/src/app/api/v1/chat/[id]/route.js
@@ -9,10 +9,7 @@ export async function GET(req, { params }) {
     const data = await getChatInfoById(params.id);
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }
 
@@ -21,9 +18,6 @@ export async function DELETE(req, { params }) {
     const data = await deleteChatChannel(params.id);
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/chat/all/route.js
+++ b/src/app/api/v1/chat/all/route.js
@@ -8,9 +8,6 @@ export async function DELETE(req) {
     const data = await clearChatHistory();
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/chat/route.js
+++ b/src/app/api/v1/chat/route.js
@@ -6,9 +6,6 @@ export async function GET(req) {
     const data = await getChatInfo();
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/plaid/accounts/route.js
+++ b/src/app/api/v1/plaid/accounts/route.js
@@ -6,9 +6,6 @@ export async function GET(req) {
     const data = await accounts();
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/plaid/categories/route.js
+++ b/src/app/api/v1/plaid/categories/route.js
@@ -6,9 +6,6 @@ export async function GET(req) {
     const data = await getAllCategories();
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/plaid/create_link_token/route.js
+++ b/src/app/api/v1/plaid/create_link_token/route.js
@@ -6,9 +6,6 @@ export async function GET(req) {
     const data = await createLinkToken();
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/plaid/set_access_token/route.js
+++ b/src/app/api/v1/plaid/set_access_token/route.js
@@ -7,9 +7,6 @@ export async function POST(req) {
     const data = await setAccessToken(reqInfo);
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/plaid/transactions/all/route.js
+++ b/src/app/api/v1/plaid/transactions/all/route.js
@@ -6,9 +6,6 @@ export async function GET(req) {
     const data = await transactionsSyncAll();
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/plaid/transactions/route.js
+++ b/src/app/api/v1/plaid/transactions/route.js
@@ -6,9 +6,6 @@ export async function GET(req) {
     const data = await transactions();
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/transaction/getData/route.js
+++ b/src/app/api/v1/transaction/getData/route.js
@@ -8,9 +8,6 @@ export async function POST(req) {
     console.log(JSON.stringify(data, null, 2));
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/user/charts/route.js
+++ b/src/app/api/v1/user/charts/route.js
@@ -7,9 +7,6 @@ export async function POST(req) {
     const data = await getChartInfo(reqInfo);
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/user/dashboard/route.js
+++ b/src/app/api/v1/user/dashboard/route.js
@@ -6,9 +6,6 @@ export async function GET(req) {
     const data = await getDashboard();
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/user/item/[id]/route.js
+++ b/src/app/api/v1/user/item/[id]/route.js
@@ -6,9 +6,6 @@ export async function DELETE(req, { params }) {
     const data = await deleteItemInfoById(params.id);
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/user/route.js
+++ b/src/app/api/v1/user/route.js
@@ -10,10 +10,7 @@ export async function GET(req) {
     const data = await getUserInfo();
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }
 
@@ -26,10 +23,7 @@ export async function POST(req) {
       status: 200,
     });
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }
 
@@ -38,9 +32,6 @@ export async function DELETE(req) {
     const data = await deleteUserAccount();
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/user/users/pay/route.js
+++ b/src/app/api/v1/user/users/pay/route.js
@@ -7,9 +7,6 @@ export async function POST(req) {
     const data = await setUserPayByEmail(reqInfo);
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }

--- a/src/app/api/v1/user/users/route.js
+++ b/src/app/api/v1/user/users/route.js
@@ -7,9 +7,6 @@ export async function POST(req) {
     const data = await getAllUsers(filter);
     return NextResponse.json(data);
   } catch (err) {
-    return NextResponse.json({
-      message: err.message,
-      status: 500,
-    });
+    return NextResponse.json({ message: err.message }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- handle API errors with proper HTTP status codes instead of embedding the status in JSON

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b034df80832d9a80e7df6599f408