### PR TITLE
Fix Plaid link init flow

### DIFF
--- a/src/components/ConnectButton.tsx
+++ b/src/components/ConnectButton.tsx
@@ -10,10 +10,11 @@ import { isEmpty } from "@/utils/util";
 import { RootState } from "@/store";
 import { AnyAction } from 'redux';
 import { Dispatch } from 'redux';
+import { toast } from 'sonner'
 import { Button } from "./ui/button";
 
 const ConnectButton = ({ children, type, setShowConnectModal }: { children: React.ReactNode, type: string | number, setShowConnectModal: (show: boolean) => void }) => {
-    const { linkToken } = useSelector((state: RootState) => state.plaid);
+    const { linkToken, linkTokenError } = useSelector((state: RootState) => state.plaid);
     const { items: linkInfo } = useSelector((state: RootState) => state.user);
 
     const dispatch = useDispatch<Dispatch<AnyAction>>();
@@ -52,6 +53,12 @@ const ConnectButton = ({ children, type, setShowConnectModal }: { children: Reac
     const [openAfterFetch, setOpenAfterFetch] = useState(false);
 
     useEffect(() => {
+        if (linkTokenError && !isEmpty(linkTokenError.error_message)) {
+            toast.error(linkTokenError.error_message || 'Failed to create link token');
+        }
+    }, [linkTokenError]);
+
+    useEffect(() => {
         if (openAfterFetch && ready && !isEmpty(linkToken)) {
             open();
             setOpenAfterFetch(false);
@@ -82,7 +89,7 @@ const ConnectButton = ({ children, type, setShowConnectModal }: { children: Reac
     return (
         <Button
             onClick={handleOpenPlaidLink}
-            disabled={!ready || isEmpty(linkToken)}
+            disabled={!ready}
         >
             {children}
         </Button>

--- a/src/hooks/usePlaidInit.js
+++ b/src/hooks/usePlaidInit.js
@@ -10,12 +10,18 @@ const usePlaidInit = () => {
     const init = useCallback(async () => {
         const res = await apiCall.get("/api/v1/plaid/create_link_token");
         if (res.status !== 200) {
-            dispatch(setPlaidState({ linkToken: null, linkSuccess: true }));
+            dispatch(
+                setPlaidState({
+                    linkToken: null,
+                    linkSuccess: true,
+                    linkTokenError: res.data,
+                })
+            );
             return;
         }
         const data = await res.data;
         dispatch(
-            setPlaidState({ linkToken: data.link_token, linkSuccess: true })
+            setPlaidState({ linkToken: data.link_token, linkSuccess: true, linkTokenError: { error_message: "" } })
         );
     }, [dispatch, linkToken]);
 


### PR DESCRIPTION
## Summary
- show Plaid link token errors in ConnectButton
- retry Plaid init on button click and stop disabling button when link token missing

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848be4d1e44832da944df14dbe45fbe